### PR TITLE
[MISC] Pydantic model validation

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -5,3 +5,7 @@
 
 pull-site:
   description: Unpack latest version of website from remote source.
+  params:
+    url:
+      type: string
+      description: URL where to fetch information from.

--- a/lib/charms/core/classes.py
+++ b/lib/charms/core/classes.py
@@ -1,0 +1,44 @@
+from functools import cached_property
+from functools import wraps
+from typing import TypeVar, Generic, Type, Callable, Union
+
+from ops.charm import CharmBase, ActionEvent
+from pydantic import BaseModel, ValidationError
+
+TypedConfig = TypeVar("TypedConfig", bound=BaseModel)
+
+T = TypeVar("T", bound=BaseModel)
+S = TypeVar("S", bound=BaseModel)
+
+
+class TypeSafeCharmBase(CharmBase, Generic[TypedConfig]):
+    """Class to be used for extending config-typed charms."""
+
+    config_type: Type[TypedConfig]
+
+    @cached_property
+    def config(self) -> TypedConfig:
+        """Return a config instance, which is validated and parsed using the provided pydantic class."""
+        translated_keys = {k.replace("-", "_"): v for k, v in self.model.config.items()}
+        return self.config_type(**translated_keys)
+
+
+def validate_params(cls: Type[T]):
+    """Return a decorator to allow pydantic parsing of action parameters.
+
+       Args:
+           app_model: Pydantic class representing the model to be used for parsing the content of the action parameter
+    """
+    def decorator(f: Callable[[CharmBase, ActionEvent, Union[T, ValidationError]], S]) -> Callable[
+        [CharmBase, ActionEvent], S]:
+        @wraps(f)
+        def event_wrapper(self: CharmBase, event: ActionEvent):
+            try:
+                params = cls(**{key.translate("-", "_"): value for key, value in event.params.items()})
+            except ValidationError as e:
+                params = e
+            return f(self, event, params)
+
+        return event_wrapper
+
+    return decorator

--- a/lib/charms/core/relations.py
+++ b/lib/charms/core/relations.py
@@ -1,0 +1,92 @@
+import json
+from functools import wraps
+from typing import TypeVar, Type, Callable, Optional, Union
+
+import pydantic
+from ops.charm import CharmBase, RelationEvent
+from ops.model import RelationDataContent
+from pydantic import BaseModel, ValidationError
+
+S = TypeVar("S")
+T = TypeVar("T", bound=BaseModel)
+AppModel = TypeVar("AppModel", bound=BaseModel)
+UnitModel = TypeVar("UnitModel", bound=BaseModel)
+
+
+def write(relation_data: RelationDataContent, model: BaseModel):
+    """Write the data contained in a domain object to the relation databag.
+
+    Args:
+        relation_data: pointer to the relation databag
+        model: instance of pydantic model to be written
+    """
+    for key, value in model.dict(exclude_none=True).items():
+        relation_data[key.replace("_", "-")] = str(value) if isinstance(value, str) or isinstance(value, int) \
+            else json.dumps(value)
+
+
+def read(relation_data: RelationDataContent, obj: Type[T]) -> T:
+    """Read data from a relation databag and parse it into a domain object.
+
+    Args:
+        relation_data: pointer to the relation databag
+        obj: pydantic class represeting the model to be used for parsing
+    """
+    return obj(**{
+        field_name: json.loads(relation_data[parsed_key])
+        for field_name, field in obj.__fields__.items()
+        if (parsed_key := field_name.replace("_", "-")) in relation_data
+    }, relation_data=relation_data)
+
+
+def parse_relation_data(app_model: Optional[Type[AppModel]] = None, unit_model: Optional[Type[UnitModel]] = None):
+    """Return a decorator to allow pydantic parsing of the app and unit databags.
+
+    Args:
+        app_model: Pydantic class representing the model to be used for parsing the content of the app databag. None
+            if no parsing ought to be done.
+        unit_model: Pydantic class representing the model to be used for parsing the content of the unit databag. None
+            if no parsing ought to be done.
+    """
+    def decorator(f: Callable[[
+        CharmBase, RelationEvent, Union[AppModel, ValidationError], Union[UnitModel, ValidationError]
+    ], S]) -> Callable[[CharmBase, RelationEvent], S]:
+        @wraps(f)
+        def event_wrapper(self: CharmBase, event: RelationEvent):
+
+            try:
+                app_data = read(event.relation.data[event.app], app_model) if app_model is not None else None
+            except pydantic.ValidationError as e:
+                app_data = e
+
+            try:
+                unit_data = read(event.relation.data[event.unit], unit_model) if unit_model is not None else None
+            except pydantic.ValidationError as e:
+                unit_data = e
+
+            return f(self, event, app_data, unit_data)
+
+        return event_wrapper
+
+    return decorator
+
+
+class RelationDataModel(BaseModel):
+    """Base class to be used for creating data models to be used for relation databags."""
+
+    def write(self, relation_data: RelationDataContent):
+        """Write data to a relation databag.
+
+        Args:
+            relation_data: pointer to the relation databag
+        """
+        return write(relation_data, self)
+
+    @classmethod
+    def read(cls, relation_data: RelationDataContent) -> 'RelationDataModel':
+        """Read data from a relation databag and parse it as an instance of the pydantic class.
+
+        Args:
+            relation_data: pointer to the relation databag
+        """
+        return read(relation_data, cls)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -29,3 +29,7 @@ storage:
 requires:
   ingress:
     interface: ingress
+
+peers:
+  cluster:
+    interface: cluster-replicas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops>1.5
+pydantic==1.10.2

--- a/src/domain/config.py
+++ b/src/domain/config.py
@@ -1,0 +1,39 @@
+from typing import List
+from pydantic import BaseModel, root_validator, validator
+
+from charms.core.relations import RelationDataModel
+
+
+class HelloKubeconConfig(BaseModel):
+    """Data model for charm config."""
+
+    external_hostname: str
+    redirect_map: str
+
+    @root_validator(pre=False)
+    def combined_field_validator(cls, values):
+        if values.get("external_hostname") == values.get("redirect_map"):
+            raise ValueError("The two values cannot be the same")
+        return values
+
+
+class PullActionModel(BaseModel):
+    """Data model for parameters of the pull action."""
+
+    url: str
+
+    @validator('url')
+    def is_url(cls, v: str):
+        if not v.startswith("http"):
+            raise ValueError('url should be starting with http')
+        return v
+
+
+class SubField(BaseModel):
+    """Data model for a subfield of a complicated property in the relation databag."""
+    subkey: str
+
+class PeerRelationModel(RelationDataModel):
+    """Data model for the relation databag."""
+    my_key: float
+    complex_property: List[SubField]


### PR DESCRIPTION
This is a first draft for introducing a way to validate, parse and type-annotate the different data structures we use in charms using [pydantic](https://docs.pydantic.dev/). 

In particular, the dict-like data structure for config, action parameters and databag are encoded using pydantic BaseModel-derived class, in order to:

* **Enhance Validation**: we can create custom business logic to validate single parameters (see validation for `PullActionModel`), or even have validators that acts across different fields (see validation for `HelloKubeconConfig`)
* **Ehnance Parsing**: by loading data into pydantic object we can both allow for more native types (e.g. float) to be used in configuration/parameters as well as specify even nested complex objects for databags (e.g. see `complex_property` on `PeerRelationModel`
* **Promote typed-annotate objects** for improving static typing checks (mypy), by moving from dict-like object to classes with typed-annotated properties. 

### Define Config Model and Validations

The mail idea here is to swap from using dict-like objects to dataclass-like objects, for storing config, action parameters and databag informations. One solution would be to use dataclass, which is python native

```python
from dataclasses import dataclass 

@dataclass
class MyConfig:
    my_key: int
    my_optional_key: Optional[str]
```
However, there is no validation on this, as you could also provide other types, with no-automatic parsing or error thrown by python 

```python
dataclass = MyConfig("abc")
dataclass.my_key # this should return "abc"
```

pydantic basically adds parsing and validation on top of dataclasses, and can be easily integrated:

```python
from pydantic import BaseModel

class MyConfig(BaseModel):
    my_key: int
    my_optional_key: Optional[str]

dataclass = MyConfig("1")
dataclass.my_key # this returns 1

dataclass = MyConfig("abc")
dataclass.my_key # this returns an error

```

Moreover, one can extend type validation with more business logic by creating custom validators integrated in the class

```python
from pydantic import BaseModel

class MyConfig(BaseModel):
    my_key: int
    
    @validator("my_key")
     def is_lower_than_100(cls, v: int):
         if v > 100:
             raise ValueError("Too high")
```

Please for more information refer to the [pydantic docs page](https://docs.pydantic.dev/)


### Parsed Config

`TypeSafeCharmBase` class is used to enforce typing for configurations when defining the charm

```python
class MyCharm(TypeSafeCharmBase[ConfigModel]):
    config_type = ConfigModel

     # everywhere in the code you will have config already parsed and validate
     def my_method(self):
         self.config: ConfigModel
```

### Parsed Action Parameters

In order to parse action parameters, we have defined a decorator to be applied to action event callbacks:

```python
@validate_params(PullActionModel)
def _pull_site_action(self, event: ActionEvent, params: Optional[Union[PullActionModel, ValidationError]] = None):
    ....
```

Note that this changes the signature of the callbacks by adding an extra parameter with the parsed counterpart of the 
`event.params` dict-like field. If validation fails, we return (not throw!) the exception, to be handled (or raised) in the callback. 

### Parsed Databag

In order to parse databag fields, we have defined a decorator to be applied to base relation event callbacks:

```python
@parse_relation_data(app_model=AppDataModel, unit_model=UnitDataModel)
    def _on_cluster_relation_joined(
            self, event: RelationEvent,
            app_data: Optional[Union[AppDataModel, ValidationError]] = None,
            unit_data: Optional[Union[UnitDataModel, ValidationError]] = None
    ) -> None:
    ...
```

Note that this changes the signature of the callbacks by adding two extra parameter: one for the parsed counterpart of the 
app databag and the other for the parsed counterpart of the unit databag. 

Alternatively, we could also parse a `RelationDataContent` using the `RelationDataModel` class, which is pydantic `BaseModel` derived class:

```python
class MyModel(RelationDataModel):
    my_value: str

my_model = MyModel.read(relation_data: RelationDataContent)
``` 

The data can also be written to the `RelationDataContent`

```python
parsed = my_model.write(relation_data: RelationDataContent)
``` 


### Why pydantic

Pydantic has some good points:

* It is becoming a pretty popular project, with an active community (12k stars,  1k forks, last commit 4h ago)
* It is user-friendly, light way and fast
* It supports code generation, namely compiles JSON schema-like files to produce the associated classes to be used as models, see [here](https://docs.pydantic.dev/datamodel_code_generator/)

Having said this, other validating backend can possibly be used. If someone has suggestions, we could compare the two and figure out the best one. The implementation done here should be easily transferred to other validating, parsing backends.
